### PR TITLE
Fix ^k to work as well as ^u

### DIFF
--- a/gtk-emacs-theme-like.ahk
+++ b/gtk-emacs-theme-like.ahk
@@ -266,10 +266,12 @@ is_target()
   If is_target()
     Send %A_ThisHotkey%
   Else
+  {
     Send {ShiftDown}{END}{SHIFTUP}
     Sleep 50
     Send {Del}
     ;Send ^x
+  }
   Return
 
 ;


### PR DESCRIPTION
ありがたく使わせていただいております。
`^k` のみ、うまく動作しませんでしたので、`^u` と同様になるよう、変更しました。